### PR TITLE
Offer to give a talk on chatops

### DIFF
--- a/speakers.md
+++ b/speakers.md
@@ -16,3 +16,4 @@ Are you interested in speaking?  Please submit a pull request to this page with 
 * Starting a new position, what's it like, strategies for getting productive, etc. - Mark Cornick.
 * Cumulus Networks 
 * Sean Killeen - TeamCity + OctopusDeploy: BFFs
+* Sean Walberg - WaterBoy, my robotic co-worker


### PR DESCRIPTION
I have a talk prepared that I'll be giving in late May at DevOpsDays Toronto on the way we're using chat automation. I could present this talk on May 10 at DevOpsDC as a practice run, or at a later meeting once I figure out which jokes land and which should be cut.
