### PR TITLE
adding a talk at the suggestion of victoria guido

### DIFF
--- a/speakers.md
+++ b/speakers.md
@@ -14,3 +14,4 @@ Are you interested in speaking?  Please submit a pull request to this page with 
 * [Glenn Buckholz] (https://www.coveros.com/staff/glenn-buckholz/) - Use Docker to Speed up your Feedback Cycles
 * Elise Walker - (https://github.com/Kindafearless) DevOps Maturity - Not all DevOps are created equal
 * Kyle Day / Glenna Gallagher - From Puppet to Ansible: A journey of automation on a Web Content Mgmt Platform  
+* [Julka Grodel](https://github.com/julka) - Is your code ready for PHP7?


### PR DESCRIPTION
Abstract: 
People are excited about PHP7. Performance benchmarks show an impressive improvement over PHP5. This is the first major release since PHP5 and includes **backward incompatible** changes that may alter the way your code works or even throw errors where you've never seen them before. I have to support back to PHP 5.2.4. That's over 9 years of PHP! How about you? Let's talk about important changes in variable & error handling, changed functions, removed functions and their alternatives, and more. We'll also talk about resources for more details on PHP7 to get your cody ready to run in the newest environments. 

I'll also be giving a version of this talk at [WordCamp Europe](https://2017.europe.wordcamp.org/session/is-your-code-ready-for-php7/) in June. 

If you feel this might be of interest to your community, can we do this in July or later, please?